### PR TITLE
Several URLs in the same message

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "charset": "^1.0.0"
   },
   "devDependencies": {
-    "chai": "^2.3.0",
+    "chai": "^3.5.0",
     "hubot-test-helper": "1.3.0",
     "coffee-script": "^1.9.3",
     "mocha": "^2.2.5",

--- a/src/tests/hubot-url-title.coffee
+++ b/src/tests/hubot-url-title.coffee
@@ -6,6 +6,8 @@ co = require('co')
 expect = require('chai').expect
 
 describe 'hubot-url-title', ->
+  this.timeout(5000)
+
   beforeEach ->
     @room = helper.createRoom(httpd: false)
 
@@ -30,5 +32,18 @@ describe 'hubot-url-title', ->
     it 'posts the title of the video', ->
       expect(@room.messages).to.eql [
         ['john', "https://github.com"]
+        ['hubot', "GitHub · Where software is built"]
+      ]
+
+  context "user posts 2 links", ->
+    beforeEach ->
+      co =>
+        yield @room.user.say 'john', "https://www.youtube.com/watch?v=u-mRU44Q5u4 https://github.com"
+        yield new Promise.delay(2000)
+
+    it 'posts the title of the video', ->
+      expect(@room.messages).to.eql [
+        ['john', "https://www.youtube.com/watch?v=u-mRU44Q5u4 https://github.com"]
+        ['hubot', "AWS re:Invent 2015 | (SEC316) Harden Your Architecture w/ Security Incident Response Simulations - YouTube"]
         ['hubot', "GitHub · Where software is built"]
       ]

--- a/src/tests/hubot-url-title.coffee
+++ b/src/tests/hubot-url-title.coffee
@@ -42,8 +42,10 @@ describe 'hubot-url-title', ->
         yield new Promise.delay(2000)
 
     it 'posts the title of the video', ->
-      expect(@room.messages).to.eql [
-        ['john', "https://www.youtube.com/watch?v=u-mRU44Q5u4 https://github.com"]
-        ['hubot', "AWS re:Invent 2015 | (SEC316) Harden Your Architecture w/ Security Incident Response Simulations - YouTube"]
-        ['hubot', "GitHub · Where software is built"]
+      expect(@room.messages[0]).to.eql ['john', "https://www.youtube.com/watch?v=u-mRU44Q5u4 https://github.com"]
+      titles = [
+        "AWS re:Invent 2015 | (SEC316) Harden Your Architecture w/ Security Incident Response Simulations - YouTube"
+        "GitHub · Where software is built"
       ]
+      expect(@room.messages[1][1]).to.be.oneOf titles
+      expect(@room.messages[2][1]).to.be.oneOf titles


### PR DESCRIPTION
I recently noticed that `hubot-url-title`, when presented with several URLs in one message, only fetches the title of the first URL. This pull request should fix this behavior.