### PR TITLE
Add option to limit length of title response

### DIFF
--- a/src/scripts/hubot-url-title.coffee
+++ b/src/scripts/hubot-url-title.coffee
@@ -13,6 +13,7 @@
 #   HUBOT_URL_TITLE_IGNORE_URLS - RegEx used to exclude Urls
 #   HUBOT_URL_TITLE_IGNORE_USERS - Comma-separated list of users to ignore
 #   HUBOT_URL_TITLE_ACCEPT_LANGUAGE - Language that can be interpreted by the client
+#   HUBOT_URL_TITLE_MAX_LEN - Maximum length for title response, -1 for no limit (default)
 #
 # Commands:
 #   http(s)://<site> - prints the title for site linked
@@ -28,6 +29,9 @@ jschardet  = require 'jschardet'
 Iconv      = require 'iconv'
 
 MAX_SIZE_DOWNLOADED_FILES = 1000000
+MAX_TITLE_LENGTH = process.env.HUBOT_URL_TITLE_MAX_LEN or '-1'
+MAX_TITLE_LENGTH = parseInt(MAX_TITLE_LENGTH)
+TITLE_LIMIT = (MAX_TITLE_LENGTH > -1)
 
 module.exports = (robot) ->
 
@@ -71,10 +75,14 @@ module.exports = (robot) ->
               html = iconv.convert(new Buffer(body, 'binary')).toString('utf-8')
               document = cheerio.load(html)
               title = document('head title').first().text().trim().replace(/\s+/g, " ")
+              if (title.length > MAX_TITLE_LENGTH) and TITLE_LIMIT
+                title = title.substr(0,MAX_TITLE_LENGTH-3) + "..."
               msg.send "#{title}"
             else
               document = cheerio.load(body)
               title = document('head title').first().text().trim().replace(/\s+/g, " ")
+              if (title.length > MAX_TITLE_LENGTH) and TITLE_LIMIT
+                title = title.substr(0,MAX_TITLE_LENGTH-3) + "..."
               msg.send "#{title}"
         .on 'data', (chunk) ->
           size += chunk.length

--- a/src/tests/hubot-url-title.coffee
+++ b/src/tests/hubot-url-title.coffee
@@ -135,3 +135,18 @@ describe 'hubot-url-title', ->
         ['amanda', "http://www.vishay.com/company/press/releases/2016/160721VLMU1610/"]
         ['hubot', "Vishay - New Vishay Intertechnology Mid-Power UV LED in 365 nm Wavelength Range Delivers Exceptionally Long Lifetime in Compact Package Redpines Vishay Systems Vishay Systems Sr. Manager, Global Communications MarCom Manager, Asia Director of Business Development, USI Electronics Vishay Intertechnology Asia Pte Ltd Vishay Semiconductor GmbH Vice President, Integrated Products Division Vishay Measurements Group Vishay Nobel Wall Street Communications Lorenzoni GmbH, Public Relations Manager, Marketing Communications Vishay Measurements Group Nobel Ltd. Vishay Nobel E.V.P., Yosun Industrial Corp. Vishay Nobel Wall Street Communications Vishay Intertechnology, Inc. Vice President of Marketing, Digi-Key Corporation Manager, MarCom Asia"]
       ]
+
+  context "page has very long title and is limited in response length", ->
+    beforeEach ->
+      process.env.HUBOT_URL_TITLE_MAX_LEN = '100'
+      nock('http://www.vishay.com/company/press/releases/2016/160721VLMU1610/').get('/').replyWithFile(200, 'src/tests/test_files/vishay.html')
+      co =>
+        @room.user.say 'amanda', "http://www.vishay.com/company/press/releases/2016/160721VLMU1610/"
+        new Promise.delay(100)
+
+    it 'responds with a truncated title', ->
+      expect(nock.isDone()).to.be.true
+      expect(@room.messages).to.eql [
+        ['amanda', "http://www.vishay.com/company/press/releases/2016/160721VLMU1610/"]
+        ['hubot', "Vishay - New Vishay Intertechnology Mid-Power UV LED in 365 nm Wavelength Range Delivers Exceptio..."]
+      ]

--- a/src/tests/hubot-url-title.coffee
+++ b/src/tests/hubot-url-title.coffee
@@ -121,3 +121,17 @@ describe 'hubot-url-title', ->
         ['john', "http://www.nytimes.com/2016/07/31/us/politics/us-wrestles-with-how-to-fight-back-against-cyberattacks.html"]
         ['hubot', "U.S. Wrestles With How to Fight Back Against Cyberattacks - The New York Times"]
       ]
+
+  context "page has very long title, but response is not limited by default", ->
+    beforeEach ->
+      nock('http://www.vishay.com/company/press/releases/2016/160721VLMU1610/').get('/').replyWithFile(200, 'src/tests/test_files/vishay.html')
+      co =>
+        @room.user.say 'amanda', "http://www.vishay.com/company/press/releases/2016/160721VLMU1610/"
+        new Promise.delay(100)
+
+    it 'responds with the complete long title', ->
+      expect(nock.isDone()).to.be.true
+      expect(@room.messages).to.eql [
+        ['amanda', "http://www.vishay.com/company/press/releases/2016/160721VLMU1610/"]
+        ['hubot', "Vishay - New Vishay Intertechnology Mid-Power UV LED in 365 nm Wavelength Range Delivers Exceptionally Long Lifetime in Compact Package Redpines Vishay Systems Vishay Systems Sr. Manager, Global Communications MarCom Manager, Asia Director of Business Development, USI Electronics Vishay Intertechnology Asia Pte Ltd Vishay Semiconductor GmbH Vice President, Integrated Products Division Vishay Measurements Group Vishay Nobel Wall Street Communications Lorenzoni GmbH, Public Relations Manager, Marketing Communications Vishay Measurements Group Nobel Ltd. Vishay Nobel E.V.P., Yosun Industrial Corp. Vishay Nobel Wall Street Communications Vishay Intertechnology, Inc. Vice President of Marketing, Digi-Key Corporation Manager, MarCom Asia"]
+      ]

--- a/src/tests/test_files/vishay.html
+++ b/src/tests/test_files/vishay.html
@@ -1,0 +1,334 @@
+<!DOCTYPE html
+  PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+      <meta name="pagetype" content="Press">
+      	
+      <meta name="author" content="Vishay">
+      	
+      <meta name="description" content="Vishay">
+      	
+      <meta name="keyword" content="Vishay">
+      
+      <title>Vishay - New Vishay Intertechnology Mid-Power UV LED in 365 nm Wavelength Range Delivers Exceptionally Long Lifetime in Compact
+         Package Redpines Vishay Systems Vishay Systems Sr. Manager, Global Communications MarCom Manager, Asia Director of Business
+         Development, USI Electronics Vishay Intertechnology Asia Pte Ltd Vishay Semiconductor GmbH Vice President, Integrated Products
+         Division Vishay Measurements Group Vishay Nobel Wall Street Communications Lorenzoni GmbH, Public Relations Manager, Marketing
+         Communications Vishay Measurements Group Nobel Ltd. Vishay Nobel E.V.P., Yosun Industrial Corp. Vishay Nobel Wall Street Communications
+         Vishay Intertechnology, Inc. Vice President of Marketing, Digi-Key 
+         Corporation Manager, MarCom Asia
+      </title>
+      	
+      <link rel="stylesheet" type="text/css" media="screen, print" href="/styles/screen.css">
+      	
+      <link rel="stylesheet" type="text/css" media="screen" href="/styles/literature.css">
+      	
+      <!--<link rel="stylesheet" type="text/css" media="print" href="/styles/print.css" />-->
+      	
+      <link rel="stylesheet" type="text/css" href="/styles/accordion.css">
+      	
+      <link rel="stylesheet" type="text/css" href="/styles/ams.css">
+      	
+      <!--<link rel="stylesheet" type="text/css" href="/styles/banner-ads.css" />-->
+      	
+      <!--<link id="adv-css" rel="stylesheet" type="text/css" href="/styles/advertiles.css" />-->
+      	
+      	
+      <link rel="stylesheet" type="text/css" href="/styles/table.css">	
+      
+      	
+      <!-- *********************** Start of Solr Search *********************** -->
+      	
+      <link rel="stylesheet" href="/search.webapp/css/search-suggestions.css" type="text/css">
+      	
+      <!-- *********************** End of Solr Search *********************** -->
+      
+      <link title="preview print" href="/styles/print.css" media="screen" type="text/css" rel="alternate stylesheet">
+      <link href="/styles/print.css" media="print" type="text/css" rel="stylesheet"><script src="/scripts/satelliteLib-fbe223f18ef769346ae0b40d373fbc7ac64698c9.js" type="text/javascript"></script><script src="/scripts/rollover.js" type="text/javascript"></script><script src="/search.webapp/js/jquery-new.js" type="text/javascript"></script><script src="/search.webapp/js/jquery-migrate.js" type="text/javascript"></script><script src="/scripts/VISHAY.js" type="text/javascript"></script><script src="/scripts/jquery.cookies.2.2.0.min.js" type="text/javascript"></script><script src="/scripts/cookie.js" type="text/javascript"></script><script src="/search.webapp/js/jquery.dataTables.js" type="text/javascript"></script><script src="/search.webapp/js/jquery-ui.min-new.js" type="text/javascript"></script><script src="/search.webapp/js/search.js" type="text/javascript"></script><script src="/scripts/ams.js" type="text/javascript"></script><script src="/scripts/webtrends-custom.js" type="text/javascript"></script><script src="/scripts/header-redesign.js" type="text/javascript"></script><script type="text/javascript">
+				$(document).ready(function($) {
+					
+							new VISHAY.Search.SearchManager('/search.webapp/', '');
+						
+					
+					new VISHAY.WebtrendsCustom();
+					
+					new VISHAY.HeaderRedesign();					
+					
+					new VISHAY.Ads();
+				});
+				
+				
+			</script><script src="/scripts/adobe/6a1ffc5abe3087be4ead5451c1651f74ee0672f3/s-code-contents-607b2cb1bf0e12f5b332115fa22066d07bc69cdb.js" type="text/javascript"></script><script src="/scripts/VISHAY.Analytics.js" type="text/javascript"></script><script src="/scripts/VISHAY.Analytics.Common.js" type="text/javascript"></script><script src="/scripts/VISHAY.Analytics.Clicks.js" type="text/javascript"></script><script src="/scripts/setlang.js" type="text/javascript"></script><script src="/scripts/new-window.js" type="text/javascript"></script><script src="/scripts/detect-mobile.js" type="text/javascript"></script><script src="/scripts/print.js" type="text/javascript"></script><script type="text/javascript">
+						var path = window.location.pathname;
+						$(document).ready(function(){
+							var sector = $("#selSector")
+							var paths = path.split("/");
+							sector.val(paths[4]);
+							sector.change(function(){
+								var val = $(this).val();
+								if (val != '')
+									window.location.href = "/company/press/product-releases/" + val + "/";
+							});
+							//ethics
+							 $('a#newWindow').click(function(e){
+								e.preventDefault();
+								var params = [
+									'height='+screen.height,
+									'width='+screen.width
+								].join(',');
+								window.open($(this).attr('href'), 'mywin', params);
+								return false;
+							 });
+							  $('.tblEthics a').click(function(e){
+								e.preventDefault();
+								var params = [
+									'height='+screen.height,
+									'width='+screen.width
+								].join(',');
+								window.open($(this).attr('href'), 'mywin', params);
+								return false;
+							 });
+						});
+					</script><script type="text/javascript">
+									jQuery( function(){					
+										jQuery( document ).ready( function(){
+													jQuery( ".accordion_content:not(1)" ).hide();
+													jQuery( ".accordion_content:eq(1)" ).show();
+													jQuery( ".accordion_toggle:eq(1)" ).addClass("accordion_toggle_active");
+												});
+									});									
+								</script><script type="text/javascript" src="/scripts/accordion-jquery-revamped.js"></script><script src="/scripts/feedback.js" type="text/javascript"></script><script type="text/javascript">
+			
+				var _gaq = _gaq || [];
+				_gaq.push(['_setAccount', 'UA-1852847-1']);
+				_gaq.push(['_trackPageview']);
+				
+				(function() {
+					var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+					ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+					var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+				})();
+				jQuery(document).ready(function($) {
+					//$("#web-survey-link").css("display", "none");
+					var zIndexNumber = 10;
+					if($.browser.msie && parseInt($.browser.version, 10) == 7) {
+						   // Brute force for feedback to be always on top 
+						   
+					}
+				}); // jQuery ready
+			</script></head>
+   <body><input value="" id="linkClicked" type="hidden"><input value="" id="languageSet" type="hidden"><div id="wrapper">
+         <header>
+            <div style="position:absolute; z-index: 10;" id="myEditTable"></div>
+            <div id="header"><a class="logo" href="/"><img alt="Vishay" src="/images/logo.gif"><img alt="Build Vishay into your Design" src="/images/tagline.gif"></a><div class="languages">
+                  <ul id="languge">
+                     <li class="lang"><a href="#">Language<img src="/images/arrowdown.png" class="arrow"></a><ul id="menu">
+                           <li><a href="javascript:setLang('en')">&nbsp;English&nbsp;</a></li>
+                           <li><a href="javascript:setLang('ja')">&nbsp;&#26085;&#26412;&#35486;&nbsp;</a></li>
+                           <li><a href="javascript:setLang('zh')">&nbsp;&#31616;&#20307;&#20013;&#25991;&nbsp;</a></li>
+                        </ul>
+                     </li>
+                  </ul>
+               </div>
+               <div class="searchContain">
+                  <form action="/search" method="get" name="search" autocomplete="off" id="frmPart"><input placeholder="Part #/Keyword Search" id="sbox" name="query" type="text" class="searchTxtField"><div id="btnPart" class="searchButton">
+                        <table cellspacing="0" cellpadding="0">
+                           <tr>
+                              <td>Go</td>
+                           </tr>
+                        </table>
+                     </div><input value="part" name="searchChoice" type="hidden"></form>
+                  <form action="/search" method="get" name="cross" autocomplete="off" id="frmCross"><input placeholder="Cross-Reference Search" id="xbox" name="query" type="text" class="searchTxtField"><div id="btnCross" class="searchButton">
+                        <table cellspacing="0" cellpadding="0">
+                           <tr>
+                              <td>Go</td>
+                           </tr>
+                        </table>
+                     </div><input value="cross" name="searchChoice" type="hidden"></form>
+                  <div class="sbox-suggestions" id="sbox-suggestions"></div>
+                  <form action="#" method="get"><select name="paramSelect" class="paramSelect">
+                        <option>-- Parametric Search --</option>
+                        <option class="paramOpt" value="/aluminum-capacitors/param">Capacitors, Aluminum Electrolytic</option>
+                        <option class="paramOpt" value="/film-capacitors/param">Capacitors, Film</option>
+                        <option class="paramOpt" value="/tantalum-capacitors/param">Capacitors, Tantalum</option>
+                        <option class="paramOpt" value="/protection-tvs/param">Diodes, TVS Protection</option>
+                        <option class="paramOpt" value="/protection-esd/param">Diodes, ESD Protection</option>
+                        <option class="paramOpt" value="/zener-diodes/param"> Diodes, Zener Diodes</option>
+                        <option class="paramOpt" value="/inductors/param">Magnetics, Inductors</option>
+                        <option class="paramOpt" value="/inductors-transformers/param">Magnetics, Transformers</option>
+                        <option class="paramOpt" value="/mosfets/param">MOSFETs</option>
+                        <option class="paramOpt" value="/automotive-mosfets/param"> MOSFETs, Automotive</option>
+                        <optgroup id="xbox" label="more coming soon..." class="optIndent"></optgroup></select></form>
+               </div>
+            </div>
+         </header>
+         <div id="top-nav">
+            <div class="top-nav-wrapper">
+               <div onmouseover="hovered(this)" id="HOME-top-nav" onmouseout="unHovered(this,'COMPANY')" class="top-nav-home"><a href="/"><span class="top-nav-home-clickable">&nbsp;</span></a></div>
+               <div class="nav-line"></div>
+               <div onmouseover="hovered(this)" id="PRODUCTS-top-nav" onmouseout="unHovered(this,'COMPANY')" class="top-nav-button"><a href="/products/">PRODUCTS</a></div>
+               <div class="nav-line"></div>
+               <div onmouseover="hovered(this)" id="APPLICATIONS-top-nav" onmouseout="unHovered(this,'COMPANY')" class="top-nav-button"><a href="/applications/">APPLICATIONS</a></div>
+               <div class="nav-line"></div>
+               <div onmouseover="hovered(this)" id="COMPANY-top-nav" onmouseout="unHovered(this,'COMPANY')" class="top-nav-button-hover"><a href="/company/">COMPANY INFO</a></div>
+               <div class="nav-line"></div>
+               <div onmouseover="hovered(this)" id="QUALITY-top-nav" onmouseout="unHovered(this,'COMPANY')" class="top-nav-quality"><a href="/quality/">QUALITY AND <br>ENVIRONMENTAL</a></div>
+               <div class="nav-line"></div>
+            </div>
+         </div>
+         <div id="secondaryNav" class="printer-friendly"><a href="/company/about/">About Vishay</a><a href="/company/awards/">Awards</a><a href="/company/brands/">Brands</a><a href="http://hr.vishay.com/">Careers</a><a href="/company/contacts/">Contacts</a><a href="/company/ethics/">Ethics</a><a href="http://ir.vishay.com">Investor Relations</a><a href="/company/press/">Product News</a><a href="/company/terms/">Terms and Conditions</a><a href="/company/trade-shows/">Trade Shows</a></div>
+         <div id="breadCrumbs"><span class="breadcrumb"><a href="/company/">Company Info</a>&nbsp;»&nbsp;
+               <a href="/company/press/">Product News</a>&nbsp;»&nbsp;
+               </span><span class="breadcrumb"><a href="/company/press/releases/2016/">2016&nbsp;Releases</a>&nbsp;»&nbsp;
+               </span><span class="breadtitle">New Vishay Intertechnology Mid-Power UV LED in 365 nm Wavelengt ...</span></div>
+         <div class="clearfix" id="content">
+            <div id="content" class="firstContent printer-friendly"><br><table width="100%" border="0" cellpadding="0" cellspacing="0" align="left">
+                  <tr>
+                     <td align="left">
+                        <div class="pf-show">
+                           <div id="prfrm"><a href=".">&lt; Back</a> &nbsp;
+                              			  
+                              			  <input type="button" onclick="window.print()" value="Print"></div>
+                        </div>
+                        <div class="pf-show">
+                           <p><strong>For more information:</strong><br>Media contact -&nbsp;
+                              							  Bob Decker, Redpines<br>Phone:&nbsp;
+                              								1.415.409.0233&nbsp;<br>Fax:&nbsp;
+                              								1.650.618.1512&nbsp;<br>E-mail:&nbsp; 
+                              							<a href="mailto:bob.decker@redpinesgroup.com">bob.decker@redpinesgroup.com</a><br><br>Sales contact:&nbsp; <br><div class="pf-show"><a href="http://www.vishay.com/company/contacts/">http://www.vishay.com/company/contacts/</a></div>
+                              <div class="pf-hide"><a href="http://www.vishay.com/company/contacts/">http://www.vishay.com/<br>company/contacts/</a><br></div>
+                           </p>
+                        </div>
+                        <div class="pr-contact">
+                           <h6><b>New Vishay Intertechnology Mid-Power UV LED in 365 nm Wavelength Range Delivers Exceptionally Long Lifetime in Compact Package</b></h6><br><div class="press-subtitle">
+                              <p><b><i>Featuring Silicone Lens, Device Provides Energy-Saving Replacement for Mercury Lamps in Medical, Industrial, and Printing
+                                       Applications</i></b></p>
+                           </div><br></div>
+                        <div class="pressreleaseCallOut"><img vspace="5" hspace="10" src="/images/press-releases/160721VLMU1610.png" alt="VLMU"><div class="pf-hide">
+                              <h3>Products mentioned:</h3><a href="/product?docid=84374">VLMU1610-365-135</a><br></div>
+                        </div>
+                        <div class="pressreleaseCallOut2"><script type="text/javascript">writePrinterFriendly('Printer-friendly version')
+			  document.getElementById('printFr').click = switchPrint();
+			</script><div class="pf-hide">
+                              <table border="0" width="0%">
+                                 <tr>
+                                    <td><strong>For more information:</strong><br>Media contact -&nbsp;
+                                       							  Bob Decker, Redpines<br>Phone:&nbsp;
+                                       								1.415.409.0233&nbsp;<br>Fax:&nbsp;
+                                       								1.650.618.1512&nbsp;<br>E-mail:&nbsp; 
+                                       							<a href="mailto:bob.decker@redpinesgroup.com">bob.decker@redpinesgroup.com</a><br><br>Sales contact:&nbsp; <br><div class="pf-show"><a href="http://www.vishay.com/company/contacts/">http://www.vishay.com/company/contacts/</a></div>
+                                       <div class="pf-hide"><a href="http://www.vishay.com/company/contacts/">http://www.vishay.com/<br>company/contacts/</a><br></div>
+                                    </td>
+                                 </tr>
+                              </table>
+                           </div>
+                           <div class="pf-hide">
+                              <div id="lang"><br><p>This release in:</p>
+                                 <ul>
+                                    <li>English</li>
+                                    <li><a href="/company/press/releases/2016/160721VLMU1610/de">Deutsch</a></li>
+                                 </ul>
+                              </div>
+                           </div>
+                        </div>
+                        <div class="pr-content">
+                           		
+                           <p><b>MALVERN, Pa. &#8212; July 21, 2016 &#8212;</b> Vishay Intertechnology, Inc. (NYSE: VSH) today expanded its offering of mid-power UV LEDs in the 365 nm wavelength range
+                              with a new device featuring a silicone lens in a compact 1.6 mm by 1.6 mm by 1.4 mm surface-mount package. Designed to provide
+                              a reliable, energy-saving replacement for mercury lamps, the Vishay Semiconductors <a href="/ppg?84374">VLMU1610-365-135</a> delivers an exceptionally long lifetime for medical, industrial, and printing applications.
+                           </p>
+                           		
+                           <p>The silicone lens of the <a href="/ppg?84374">VLMU1610-365-135</a> enables extremely long lifetimes up to 25,000 h, compared to the typical mercury lamp lifetime of 10,000 h. The environmentally
+                              friendly UV LED is free of heavy metals and provides increased reliability with its shock resistance and immunity to degradation
+                              from frequent on / off switching. While mercury lamps require complex drive circuits and need two to 15 minutes to warm up,
+                              the <a href="/ppg?84374">VLMU1610-365-135</a> allows for the use of simple low-voltage circuitry and requires no warm-up period.
+                           </p>
+                           		
+                           <p>Built on InGaN (indium gallium nitride) technology, the device released today features typical radiant power of 18 mW at 20
+                              mA and 50 mW at 60 mA in a wavelength range between 362.5 nm and 370 nm. The <a href="/ppg?84374">VLMU1610-365-135</a> offers an emission angle of 135°. The LED&#8217;s specifications make it ideal for UV curing in nail salon, dental, and poster
+                              printing applications; blood and counterfeit money detection; and photocatalytic purification.
+                           </p>
+                           		
+                           <p>RoHS-compliant, halogen-free, and <a href="http://www.vishay.com/docs/99912/mat_cat_policy.pdf">Vishay Green</a>, the <a href="/ppg?84374">VLMU1610-365-135</a> is compatible with reflow soldering processes and features a Moisture Sensitivity Level of 3 in accordance with J-STD-020.
+                           </p>
+                           		
+                           <p>Samples and production quantities of the new UV LED are available now, with lead times of six to eight weeks.</p>
+                           	
+                           <p>
+                              <p name="Vishay">Vishay Intertechnology, Inc., a Fortune 1000 Company listed on the NYSE (VSH), is one of the world's largest manufacturers
+                                 of discrete semiconductors (diodes, MOSFETs, and infrared optoelectronics) and passive electronic components (resistors, inductors,
+                                 and capacitors). These components are used in virtually all types of electronic devices and equipment, in the industrial,
+                                 computing, automotive, consumer, telecommunications, military, aerospace, power supplies, and medical markets. Vishay&#8217;s product
+                                 innovations, successful acquisition strategy, and "one-stop shop" service have made it a global industry leader. Vishay can
+                                 be found on the Internet at www.vishay.com.<br><br>
+                                 									<img src="/images/twitter.png" style="width: 27px; height: 27px"> <a href="https://twitter.com/vishayindust">
+                                    http://twitter.com/vishayindust
+                                    </a><br>
+                                 									<img src="/images/facebook.png" style="width: 27px; height: 27px"> <a href="http://www.facebook.com/VishayIntertechnology">http://www.facebook.com/VishayIntertechnology
+                                    </a>
+                                 									
+                              </p>
+                           </p>
+                           <center>###</center>
+                           <p><em></em></p>
+                        </div>
+                     </td>
+                  </tr>
+               </table>
+            </div>
+            <div class="secondContent">
+               <div class="accordion" id="vertical_container">
+                  <div class="contactUs" onmouseover="this.style.cursor='hand'" onclick="window.location='/company/contacts/';"><img alt="Contact Us" src="/images/text_contactus.gif" class="title"><span>Sales, Authorized Distributors <br> Technical Questions...</span><a class="link" href="/company/contacts/"><img alt="Contact Us" src="/images/text_go.gif"></a></div>
+                  <div style="display:none;" class="contactUs-mil" onmouseover="this.style.cursor='hand'" onclick="window.location='/milwaukee/contact/';"><a class="link" href="/milwaukee/contact/"><img style="margin-bottom:6px;" alt="Contact Us" src="/images/contact_btn.gif" class="title"></a></div>
+                  	
+                  <div class="buyNow">
+                     		
+                     <form id="buyNowSearch" autocomplete="off" name="search" method="get" action="/search">
+                        			<img class="title" src="/images/text_buynow.gif" alt="Buy Now">
+                        			
+                        <!--<input class="textfield" style="width: 165px;" type="text" cols="20" name="query" onkeyup="ajaxSearch(this.value,0,10,event.keyCode,'buy-now','buy-now-result')" id="search-inventory"/>-->
+                        			<input class="textfield" style="width: 165px;" type="text" cols="20" name="query" id="search-inventory">
+                        			<img class="formlabel" src="/images/text_distributorStock.gif" alt="Check Distributor Stock">
+                        			
+                        <!--<div style="display:none;border:1px solid black;position:absolute; background-color:white;z-index:5;padding:0px 0px 0px 0px;margin:60px 0px 0px 13px;width:165px;" id="results-inventory"/>-->
+                        			<img class="refNumImg" src="/images/text_referencenumber2.gif" alt="Part Number/Keyword">
+                        			<input class="submit" type="image" src="/images/btn_go_matteLtBlue.gif" id="search-inventory-submit" name="search-inventory-submit">
+                        			<input type="hidden" name="type" value="inv">
+                        		
+                     </form>
+                     	
+                  </div>
+                  
+                  <!--	<div class="buyNow">
+		<img class="title" src="images/text_buynow.gif" alt="Buy Now"/>
+		<img class="formlabel" src="images/text_distributorStock.gif" alt="Check Distributor Stock"/>
+		<input class="textfield" type="text" cols="20" name=""/>
+		<img class="refNumImg" src="images/text_referencenumber2.gif" alt="Part Number/Keyword"/>
+		<input class="submit" type="image" src="images/btn_go_matteLtBlue.gif" name="submit"/>
+	</div>-->
+                  
+                  <div style="margin-top: 5px;"></div>
+                  <div style="margin-top: 5px;"></div>
+               </div>
+            </div>
+         </div>
+         <div id="footer"><a href="/products/">Products</a> | <a href="/company/">Company</a> | Press | <a href="http://ir.vishay.com">Investors</a> | <a href="/company/contacts/">Contacts</a> | <a href="/company/brands/">Brands</a> | <a href="/company/privacy-legal/">Privacy &amp; Legal</a> | <a href="/company/sitemap/">Site Map</a> | <a href="/account/your-account">Your Account</a></div><script type="text/javascript" src="/scripts/webtrends.js"></script><script type="text/javascript">
+		var _tag=new WebTrends();
+		_tag.dcsGetId();
+	</script><script type="text/javascript">
+		// Add custom parameters here.
+		//_tag.DCSext.param_name=param_value;
+		_tag.dcsCollect();
+	</script><noscript>
+            <div><img src="http://statse.webtrendslive.com/dcso26ali10000o69eyusui3w_8t3c/njs.gif?dcsuri=/nojavascript&amp;WT.js=No&amp;WT.tv=8.6.0" height="1" width="1" id="DCSIMG" alt="DCSIMG"></div>
+         </noscript>
+      </div>
+      <div id="web-survey-link"><a href="feedback" onclick="openWindow(this); return false;"><span>Feedback</span></a></div><script src="/search.webapp/js/jquery.placeholder.js" type="text/javascript"></script><script type="text/javascript">
+				
+				try {	window.onload = VISHAY.postInit(); }
+				catch (e) {  }
+			</script><script type="text/javascript">
+				_satellite.pageBottom();
+			</script></body>
+</html>


### PR DESCRIPTION
Value of HUBOT_URL_TITLE_MAX_LEN should be set to something that can be parsed by `parseInt()`. A value of around 200 should be sufficient
Defaults to -1, which results in no response length limiting

I don't like the duplication of code, but I also couldn't figure out how to get the `document` to be valid in scope after the condition to process the received page data properly as UTF-8.

This will close #24.