### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,21 +20,21 @@
   },
   "homepage": "https://github.com/dentarg/hubot-url-title",
   "dependencies": {
-    "charset": "^1.0.0",
-    "cheerio": "^0.20.0",
-    "iconv": "^2.1.11",
-    "jschardet": "^1.4.1",
+    "charset": "~1.0.0",
+    "cheerio": "~0.20.0",
+    "iconv": "~2.1.11",
+    "jschardet": "~1.4.1",
     "request": "~2.74.0",
     "underscore": "~1.8.3"
   },
   "devDependencies": {
-    "bluebird": "^3.3.1",
-    "chai": "^3.5.0",
-    "co": "^4.6.0",
-    "coffee-script": "^1.9.3",
-    "hubot-test-helper": "1.5.0",
-    "mocha": "^3.0.2",
-    "nock": "^8.0.0",
-    "npm-check-updates":"^2.8"
+    "bluebird": "~3.3.1",
+    "chai": "~3.5.0",
+    "co": "~4.6.0",
+    "coffee-script": "~1.9.3",
+    "hubot-test-helper": "~1.5.0",
+    "mocha": "~3.0.2",
+    "nock": "~8.0.0",
+    "npm-check-updates":"~2.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,20 +21,20 @@
   "homepage": "https://github.com/dentarg/hubot-url-title",
   "dependencies": {
     "charset": "^1.0.0",
-    "cheerio": "^0.19.0",
+    "cheerio": "^0.20.0",
     "iconv": "^2.1.11",
     "jschardet": "^1.4.1",
-    "request": "~2.30.0",
-    "underscore": "~1.3.3"
+    "request": "~2.74.0",
+    "underscore": "~1.8.3"
   },
   "devDependencies": {
     "bluebird": "^3.3.1",
     "chai": "^3.5.0",
     "co": "^4.6.0",
     "coffee-script": "^1.9.3",
-    "hubot-test-helper": "1.3.0",
-    "mocha": "^2.2.5",
-    "nock": "^7.7.2",
+    "hubot-test-helper": "1.5.0",
+    "mocha": "^3.0.2",
+    "nock": "^8.0.0",
     "npm-check-updates":"^2.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,12 +28,13 @@
     "underscore": "~1.3.3"
   },
   "devDependencies": {
+    "bluebird": "^3.3.1",
     "chai": "^3.5.0",
-    "hubot-test-helper": "1.3.0",
+    "co": "^4.6.0",
     "coffee-script": "^1.9.3",
+    "hubot-test-helper": "1.3.0",
     "mocha": "^2.2.5",
     "nock": "^7.7.2",
-    "bluebird": "^3.3.1",
-    "co": "^4.6.0"
+    "npm-check-updates":"^2.8"
   }
 }


### PR DESCRIPTION
This addresses #23.

Should any of the version condition characters be changed? `ncu` preserves them.